### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/web-sdk/security/code-scanning/26](https://github.com/Dargon789/web-sdk/security/code-scanning/26)

In general, the fix is to explicitly restrict the `GITHUB_TOKEN` permissions in the workflow to the minimal set needed. For this workflow, the job only checks out code and runs pnpm install/tests, which requires only read access to repository contents; no write permissions are needed.

The best fix without changing functionality is to add a `permissions` block that sets `contents: read`. You can add this at the workflow root (applies to all jobs) or inside the `test` job. Since CodeQL flags the job and there is only a single job, adding it at the job level is clear and minimally invasive. Edit `.github/workflows/test.yml` and between `runs-on: ubuntu-latest` (line 10) and `steps:` (line 12), insert:

```yaml
    permissions:
      contents: read
```

No additional methods, imports, or definitions are required, as this is purely a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add explicit read-only contents permission to the test GitHub Actions workflow job to satisfy code scanning requirements.